### PR TITLE
Update dependencies for Python 3.12 compatibility

### DIFF
--- a/tropical-cloud-ai/requirements.txt
+++ b/tropical-cloud-ai/requirements.txt
@@ -1,11 +1,10 @@
-tensorflow==2.10.0
-numpy==1.21.6
+tensorflow==2.16.1
+numpy==1.26.0
 matplotlib==3.5.1
-scikit-learn==1.0.2
-Pillow==9.0.1
-opencv-python==4.5.3.20210927
+scikit-learn==1.3.2
+Pillow==11.2.1
+opencv-python==4.11.0.86
 requests==2.26.0
-h5py==3.6.0
+h5py==3.10.0
 tqdm==4.62.3
 imageio==2.9.0
-tkinter==0.1.0


### PR DESCRIPTION
Updated several packages to versions compatible with Python 3.12, resolving installation errors and conflicts:

- numpy: 1.21.6 -> 1.26.0
- tensorflow: 2.10.0 -> 2.16.1
- scikit-learn: 1.0.2 -> 1.3.2
- Pillow: 9.0.1 -> 11.2.1
- opencv-python: 4.5.3.20210927 -> 4.11.0.86
- h5py: 3.6.0 -> 3.10.0 (to resolve conflict with tensorflow)

Removed tkinter from requirements.txt as it's a standard library module.